### PR TITLE
Leaving docker image up for running other examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN cd /opt/tfm-rdf/hdt-jni && mvn -DskipTests install
 
 RUN cd /opt/tfm-rdf/hdt-jni/hdt-java-cli/ && ./bin/rdf2hdt.sh ../../nt/test.nt ../../nt/test.hdt
 
+CMD ["tail", "-f", "/dev/null"]
 
 
 

--- a/goDocker.sh
+++ b/goDocker.sh
@@ -4,7 +4,7 @@ docker rm gccdocker
 
 docker build -t rdfjni --rm=true .
 
-docker run --name gccdocker -it rdfjni
+docker run -d --name gccdocker rdfjni
 
 # docker run --name gccdocker --mount type=bind,source="$(pwd)/data", target=/data -it rdfjni
 


### PR DESCRIPTION
it would be great if you can also create a script for running any example, sbt like (I didn't test it):

```
docker cp mydata.nt gccdocker:/
docker exec -i gccdocker /opt/tfm-rdf/hdt-jni/hdt-java-cli/bin/rdf2hdt.sh /mydata.nt /mydata.hdt
docker cp gccdocker:/mydata.hdt ./

```